### PR TITLE
blackjack web - cards stay visible after Stand action

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -22,7 +22,8 @@
 }
 
 #dealer-cards {
-  min-height: 142px !important;
+  /* min-height: 142px !important; */
+  height: 142px !important;
 }
 
 #action {


### PR DESCRIPTION
blackjack web - cards stay visible after Stand action; min-height enforced on dealer's hand to prevent player's hand from visually moving after dealer's hand is dealt