### PR TITLE
blackjack web - cards stay visible after Stand action

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -22,8 +22,7 @@
 }
 
 #dealer-cards {
-  /* min-height: 142px !important; */
-  height: 142px !important;
+  min-height: 142px;
 }
 
 #action {
@@ -513,6 +512,12 @@ input.reverse {
   }
 
   #display-controls span input#speed { width: 75% !important; }
+  
+  #dealer-cards {
+    height: calc(100vh - calc(100vh - 100%));
+    /* display: list-item; 
+    min-height: inherit; */
+  }
 
 }
 


### PR DESCRIPTION
blackjack web - cards stay visible after Stand action; min-height enforced on dealer's hand to prevent player's hand from visually moving after dealer's hand is dealt